### PR TITLE
Enable home page video looping

### DIFF
--- a/src/app/shared/layout/hero-video/hero-video.ts
+++ b/src/app/shared/layout/hero-video/hero-video.ts
@@ -25,7 +25,9 @@ export class HeroVideo implements AfterViewInit {
           playerVars: {
             autoplay: 1,
             mute: 1,
-            playsinline: 1
+            playsinline: 1,
+            loop: 1,
+            playlist: 'L00wZaW0idE'
           },
           events: {
             onReady: (event: any) => {


### PR DESCRIPTION
## Summary
- loop hero video by adding `loop` and `playlist` options

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464e09fbcc83208adee3ffa66b6449