### PR TITLE
Add registration banner section

### DIFF
--- a/src/app/home/components/home/home.html
+++ b/src/app/home/components/home/home.html
@@ -4,3 +4,4 @@
 <app-intro></app-intro>
 <app-programmes></app-programmes>
 <app-why-come></app-why-come>
+<app-registration-banner></app-registration-banner>

--- a/src/app/home/components/registration-banner/registration-banner.html
+++ b/src/app/home/components/registration-banner/registration-banner.html
@@ -1,0 +1,9 @@
+<section id="registration-banner" class="registration-banner">
+  <div class="banner-content">
+    <h2>REGISTRATIONS NOW OPEN</h2>
+    <h5>Limited availability! Book now to avoid missing out.</h5>
+    <a class="btn" href="https://campusexperiencermf.com/en/registration/">
+      Registration form
+    </a>
+  </div>
+</section>

--- a/src/app/home/components/registration-banner/registration-banner.scss
+++ b/src/app/home/components/registration-banner/registration-banner.scss
@@ -1,0 +1,36 @@
+.registration-banner {
+  background: #f9f9f9;
+  padding: 90px 0;
+}
+
+.banner-content {
+  width: 70%;
+  margin: auto;
+  text-align: center;
+}
+
+.banner-content h2 {
+  font-size: 30px;
+  color: #363636;
+  font-family: Raleway, Helvetica, sans-serif;
+  margin-bottom: 0.5rem;
+}
+
+.banner-content h5 {
+  font-family: Raleway, Helvetica, sans-serif;
+  font-size: 16px;
+  color: #8c8c8c;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+}
+
+.banner-content .btn {
+  padding: 12px 24px;
+  background: #af8542;
+  color: #fff;
+  text-decoration: none;
+  font-family: Raleway, Helvetica, sans-serif;
+  font-size: 17.6px;
+  text-transform: uppercase;
+  border-radius: 3px;
+}

--- a/src/app/home/components/registration-banner/registration-banner.ts
+++ b/src/app/home/components/registration-banner/registration-banner.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-registration-banner',
+  standalone: false,
+  templateUrl: './registration-banner.html',
+  styleUrl: './registration-banner.scss'
+})
+export class RegistrationBanner {}

--- a/src/app/home/home-module.ts
+++ b/src/app/home/home-module.ts
@@ -9,6 +9,7 @@ import {HeroVideo} from '../shared/layout/hero-video/hero-video';
 import {Intro} from './components/intro/intro';
 import {Programmes} from './components/programmes/programmes';
 import {WhyCome} from './components/why-come/why-come';
+import {RegistrationBanner} from './components/registration-banner/registration-banner';
 
 
 @NgModule({
@@ -17,6 +18,7 @@ import {WhyCome} from './components/why-come/why-come';
     Intro,
     Programmes,
     WhyCome,
+    RegistrationBanner,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
## Summary
- create `registration-banner` component with registration info
- include the banner in HomeModule declarations
- show the banner on the home page under the WhyCome section

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb83943848320973630a12d591cb3